### PR TITLE
doc: simplify installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Using [https://shields.io](https://shields.io), the executable will generate a c
 ## How to use
 Install the executable
 ```
-go get github.com/AlexBeauchemin/gobadge
-go install github.com/AlexBeauchemin/gobadge
+go install github.com/AlexBeauchemin/gobadge@latest
 ```
 Make sure you generate a coverage file with your total coverage, something like
 ```go


### PR DESCRIPTION
When you specify a version for installation, you don't need the `go get` part.

For this to properly work as expected, I'm suggesting you to publish a `v0.3.0` (the v0.2.0 does not have the `-link` flag)


Btw, thanks for this code. Simple and elegant ;) 