### PR TITLE
Use regex for replacing badge content

### DIFF
--- a/gobadge.go
+++ b/gobadge.go
@@ -126,13 +126,9 @@ func updateReadme(target string, coverage string, label string, color string, li
 	// Possible regex exprs with and without link
 	// Playground: https://goplay.tools/snippet/GWvkx43QndT
 	badgeRegexes := []*regexp.Regexp{
-		regexp.MustCompile(`!\[(\w+)\]\(https:\/\/img\.shields\.io\/badge\/(\w+)-([\d\.%]+)-(\w+)\)`), 
 		regexp.MustCompile(`\[!\[(\w+)\]\(https:\/\/img\.shields\.io\/badge\/(\w+)-([\d\.%]+)-(\w+)\)\]\((.*)\)`),
+		regexp.MustCompile(`!\[(\w+)\]\(https:\/\/img\.shields\.io\/badge\/(\w+)-([\d\.%]+)-(\w+)\)`), 
 	}
-	// badgeRegex := regexp.MustCompile(`!\[(\w+)\]\(https:\/\/img\.shields\.io\/badge\/(\w+)-([\d\.%]+)-(\w+)\)`)
-	// if link != "" {
-	// 	badgeRegex = regexp.MustCompile(`\[!\[(\w+)\]\(https:\/\/img\.shields\.io\/badge\/(\w+)-([\d\.%]+)-(\w+)\)\]\((.*)\)`)
-	// }
 
 	newBadge := "![" + label + "](https://img.shields.io/badge/" + encodedLabel + "-" + encodedCoverage + "-" + color + ")"
 	if link != "" {

--- a/gobadge.go
+++ b/gobadge.go
@@ -142,7 +142,7 @@ func updateReadme(target string, coverage string, label string, color string, li
 		if re.MatchString(string(input)) {
 			output = re.ReplaceAllString(string(input), newBadge)
 			found = true
-			goto outside
+			break
 		}
 	}
 

--- a/gobadge_test.go
+++ b/gobadge_test.go
@@ -103,6 +103,20 @@ func TestUpdateReadme(t *testing.T) {
 	assert.Equal(t, nil, err)
 	deleteFile(target)
 
+	// Test updating badge with link to badge without link
+	createFile(target, "## A Title\nA description\nContent [![Coverage](https://img.shields.io/badge/Coverage-50.01%25-green)](https://www.cnn.com)")
+	err = updateReadme(target, "40.01%", "Coverage", "green", "")
+	validateFileContent(t, target, "## A Title\nA description\nContent ![Coverage](https://img.shields.io/badge/Coverage-40.01%25-green)")
+	assert.Equal(t, nil, err)
+	deleteFile(target)
+
+	// Test updating badge without link to badge with link
+	createFile(target, "## A Title\nA description\nContent ![Coverage](https://img.shields.io/badge/Coverage-50.01%25-green)")
+	err = updateReadme(target, "50.01%", "Coverage", "green", "https://www.cnn.com")
+	validateFileContent(t, target, "## A Title\nA description\nContent [![Coverage](https://img.shields.io/badge/Coverage-50.01%25-green)](https://www.cnn.com)")
+	assert.Equal(t, nil, err)
+	deleteFile(target)
+
 	err = updateReadme("unknown.md", "50.01%", "Coverage", "green", "")
 	assert.Equal(t, "open unknown.md: no such file or directory", err.Error())
 }


### PR DESCRIPTION
This PR uses regular expressions to update the badge instead of string replace. The advantage of this approach is that we can keep the _custom_ format of badge in README file. 

Users can embed a "dummy" badge however they want in the README file. When we run the app, the badge will be merely updated with coverage value without losing the format.

If no badge found, it will have the same beahviour, where it will add the badge to the second line of README