### PR TITLE
Updating Readme to use text instead of label flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gobadge -filename=coverage.out
 |Flag                          |Default   |Description|
 |------------------------------|----------|-----------|
 |filename                      |output.out|File to scan for the coverage total|
-|label                         |Coverage  |Left-side content of the badge|
+|test                          |Coverage  |Left-side content of the badge|
 |value                         |          |Right-side content of the badge|
 |yellow                        |30        |At what percentage the badge will become yellow instead of red|
 |green                         |70        |At what percentage the badge becomes green instead of yellow|
@@ -43,7 +43,7 @@ gobadge -filename=coverage.out
 ## Examples
 ```
 gobadge -filename=coverage.out
-gobadge -label="Go Coverage" -value=55.6% -color=blue -target=OTHER_README.md
+gobadge -text="Go Coverage" -value=55.6% -color=blue -target=OTHER_README.md
 gobadge -yellow=60 -green=80
 gobadge -color=ff69b4
 gobadge -link=https://github.com/project/repo/actions/workflows/test.yml

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gobadge -filename=coverage.out
 |Flag                          |Default   |Description|
 |------------------------------|----------|-----------|
 |filename                      |output.out|File to scan for the coverage total|
-|test                          |Coverage  |Left-side content of the badge|
+|text                          |Coverage  |Left-side content of the badge|
 |value                         |          |Right-side content of the badge|
 |yellow                        |30        |At what percentage the badge will become yellow instead of red|
 |green                         |70        |At what percentage the badge becomes green instead of yellow|


### PR DESCRIPTION
The tool uses a `-text` flag instead of a `-label` flag to set the text on the left side of the badge. 

gobadge.go line 30:
```
	label := flag.String("text", "Coverage", "Text on the left side of the badge")
```

The documentation in the readme incorrectly directed the user to use a `-label` flag. This pull request updates the readme to use `-text`