### PR TITLE
Use label as part of badgeRegex to check if bagde already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # Test binary, built with `go test -c`
 *.test
 test.txt
+testS.txt
+testF.txt
 test.md
 
 # Output of the go coverage tool, specifically when used with LiteIDE

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GOBadge
-![Coverage](https://img.shields.io/badge/Coverage-77.0%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-77.3%25-brightgreen)
 
 #### 👆 Easily create and insert coverage badge (or any other badge) in your readme with go
 

--- a/gobadge.go
+++ b/gobadge.go
@@ -123,9 +123,10 @@ func updateReadme(target string, coverage string, label string, color string, li
 
 	// Possible regex exprs with and without link
 	// Playground: https://goplay.tools/snippet/GWvkx43QndT
+	baseRegex := fmt.Sprintf(`\[%s\]\(https:\/\/img\.shields\.io\/badge\/(\w+)`, regexp.QuoteMeta(label))
 	badgeRegexes := []*regexp.Regexp{
-		regexp.MustCompile(`\[!\[(\w+)\]\(https:\/\/img\.shields\.io\/badge\/(\w+)-([\d\.%]+)-(\w+)\)\]\((.*)\)`),
-		regexp.MustCompile(`!\[(\w+)\]\(https:\/\/img\.shields\.io\/badge\/(\w+)-([\d\.%]+)-(\w+)\)`),
+		regexp.MustCompile(fmt.Sprintf(`\[!%s-([\d\.%%]+)-(\w+)\)\]\((.*)\)`, baseRegex)),
+		regexp.MustCompile(fmt.Sprintf(`!%s-([\d\.%%]+)-(\w+)\)`, baseRegex)),
 	}
 
 	newBadge := "![" + label + "](https://img.shields.io/badge/" + encodedLabel + "-" + encodedCoverage + "-" + color + ")"

--- a/gobadge_test.go
+++ b/gobadge_test.go
@@ -42,6 +42,25 @@ func TestGenerateBadge(t *testing.T) {
 	assert.Equal(t, nil, err)
 	validateFileContent(t, "test.md", "## Header\n![Coverage](https://img.shields.io/badge/Coverage-33.3%25-red)\nDescription...\n")
 
+	// Test the creation of 2 differents badges
+	createFile("test.md", "## Header\nDescription...\n")
+	createFile("testF.txt", "github.com/AlexBeauchemin/go-coverage-badge/gobadge.go:53:	updateReadme\n80.0%total:                                                          (statements)            33.3%")
+	createFile("testS.txt", "github.com/AlexBeauchemin/go-coverage-badge/gobadge.go:53:	updateReadme\n80.0%total:                                                          (statements)            66.6%")
+	err = generateBadge("testF.txt", "test.md", &Params{"FirstCoverage", Threshold{50, 70}, "", "", ""})
+	assert.Equal(t, nil, err)
+	err = generateBadge("testS.txt", "test.md", &Params{"SecondCoverage", Threshold{50, 70}, "", "", ""})
+	assert.Equal(t, nil, err)
+	validateFileContent(t, "test.md", "## Header\n![SecondCoverage](https://img.shields.io/badge/SecondCoverage-66.6%25-yellow)\n![FirstCoverage](https://img.shields.io/badge/FirstCoverage-33.3%25-red)\nDescription...\n")
+
+	// Update 2 different badges
+	createFile("testF.txt", "github.com/AlexBeauchemin/go-coverage-badge/gobadge.go:53:	updateReadme\n80.0%total:                                                          (statements)            75.0%")
+	createFile("testS.txt", "github.com/AlexBeauchemin/go-coverage-badge/gobadge.go:53:	updateReadme\n80.0%total:                                                          (statements)            100.0%")
+	err = generateBadge("testF.txt", "test.md", &Params{"FirstCoverage", Threshold{50, 80}, "", "", ""})
+	assert.Equal(t, nil, err)
+	err = generateBadge("testS.txt", "test.md", &Params{"SecondCoverage", Threshold{50, 70}, "", "", ""})
+	assert.Equal(t, nil, err)
+	validateFileContent(t, "test.md", "## Header\n![SecondCoverage](https://img.shields.io/badge/SecondCoverage-100.0%25-brightgreen)\n![FirstCoverage](https://img.shields.io/badge/FirstCoverage-75.0%25-yellow)\nDescription...\n")
+
 	// Create a badge and use the provided value as coverage
 	createFile("test.md", "## Header\nDescription...\n")
 	err = generateBadge("unknown.out", "test.md", &Params{"Coverage", Threshold{50, 70}, "", "55%", ""})


### PR DESCRIPTION
This PR updates the `badgeRegexes` by using the `label` instead of the `(\w+)` regex.

Having the `label` as a part of the regex used to detect existing badge in the README offers ability to add / update multiple badges with different labels (ie a client and a server in subdirs of the same repo).

Tests have been updated to check this specific use case.